### PR TITLE
Clarify input dimensions for pcolormesh in documentation

### DIFF
--- a/docs/plotting_data.rst
+++ b/docs/plotting_data.rst
@@ -210,10 +210,13 @@ Creates a pseudo-color plot
 
 `pcolormesh(x, y, data, *args, **kwargs) <http://matplotlib.org/basemap/api/basemap_api.html#mpl_toolkits.basemap.Basemap.pcolormesh>`_
 
-* x and y are matrices of the same size as data, containing the positions of the elements in the map coordinates
+* x and y are matrices containing the positions of the elements in the map coordinates
 * data is the matrix containing the data values to plot
 * The default colormap is *jet*, but the argument *cmap* can be used to change the behavior
 * Other possible arguments are documented in the `matplotlib function docs <http://matplotlib.org/api/pyplot_api.html#matplotlib.pyplot.pcolormesh>`__
+
+Note that ideally the dimensions of x and y should be one greater than those of data;
+if the dimensions are the same, then the last row and column of data will be ignored.
 
 .. literalinclude:: ../code_examples/basic_functions/pcolormesh.py
 	:emphasize-lines: 22


### PR DESCRIPTION
The plotting data tutorial states that the `x`, `y`, and `data` inputs to pcolormesh should be of the same size, but that's not correct.  As per the `Basemap.pcolormesh` docstring, `x` and `y` should have dimensions one greater than those of data; the code will still run if they have the same size but the last row and column get dropped.